### PR TITLE
Chrome support

### DIFF
--- a/.parcelrc
+++ b/.parcelrc
@@ -1,6 +1,9 @@
 {
   "extends": "@parcel/config-webextension",
   "transformers": {
+    "manifest-*.json": [
+      "@parcel/transformer-webextension"
+    ],
     "*.{js,mjs,jsm,jsx,es6,cjs,ts,tsx}": [
       "parcel-transformer-replace",
       "@parcel/transformer-babel",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
   "scripts": {
     "watch": "npm run clean && npm run parcel:start",
     "build": "npm run clean && npm run parcel:build && npm run ext:build",
+    "build:chrome": "npm run clean && npm run parcel:build:chrome && npm run ext:build",
     "lint": "npm run ext:lint",
     "firefox": "npm run ext:run",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist web-ext-artifacts",
     "parcel:start": "parcel watch src/manifest.json --host localhost",
     "parcel:build": "parcel build src/manifest.json",
+    "parcel:build:chrome": "parcel build src/manifest-chrome.json && mv dist/manifest-chrome.json dist/manifest.json",
     "ext:run": "web-ext run -s ./dist --devtools",
     "ext:build": "web-ext build -s ./dist",
     "ext:lint": "web-ext lint -s ./dist"

--- a/src/background.ts
+++ b/src/background.ts
@@ -4,6 +4,7 @@ import { getOption, onOptionChange } from "./options";
 import { AvailableParser, getEnabledParsersWithName, getEnabledPluginsByParserName } from "./plugins";
 import type { FormatRequest, FormatResponse } from "./types";
 import { parse as parseJson } from "json5";
+import * as browser from "webextension-polyfill";
 
 const prettier = import("prettier/standalone");
 
@@ -87,7 +88,7 @@ async function ensureScriptLoaded(currentTab: Tabs.Tab) {
   });
 
   if (!results || results[0] !== true) {
-    const file = new URL("injected.ts", import.meta.url).toString();
+    const file = new URL("injected.ts", import.meta.url).pathname;
     return browser.tabs.executeScript(currentTab.id, { file });
   }
 }

--- a/src/injected.ts
+++ b/src/injected.ts
@@ -2,6 +2,7 @@ import type { Options as FormatOptions } from "prettier";
 import { getOption } from "./options";
 import { AvailableParser } from "./plugins";
 import { FormatRequest, FormatResponse } from "./types";
+import { runtime } from "webextension-polyfill";
 
 async function __prettierTextArea(parser: AvailableParser) {
   try {
@@ -23,7 +24,7 @@ async function __prettierTextArea(parser: AvailableParser) {
       code: element.value,
       options,
     };
-    const response: FormatResponse = await browser.runtime.sendMessage(request);
+    const response: FormatResponse = await runtime.sendMessage(request);
     if (response.error) throw new Error(response.error);
     element.value = response.formatted;
   } catch (e) {

--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/chrome-manifest.json",
+  "manifest_version": 3,
+  "name": "Format with Prettier",
+  "description": "Use prettier from your browser!",
+  "version": "0.0.1",
+  "background": {
+    "service_worker": "background.ts",
+    "type": "module"
+  },
+  "options_ui": {
+    "page": "options/index.html",
+    "browser_style": true
+  },
+  "permissions": ["activeTab", "contextMenus", "storage"]
+}

--- a/src/options/options-script.ts
+++ b/src/options/options-script.ts
@@ -1,6 +1,7 @@
-import { defaultOptions, getOption, getOptions, ExtensionOptions, setOption } from "../options";
+import { defaultOptions, getOption, getOptions, setOption } from "../options";
 import { parsersByName } from "../plugins";
 import { FormatRequest, FormatResponse } from "../types";
+import { runtime } from "webextension-polyfill";
 
 init().catch((e) => {
   console.error("error in options page", e.toString());
@@ -37,7 +38,7 @@ async function init() {
         options: { parser: "json5" },
         unparsedOptions: value,
       };
-      const response: FormatResponse = await browser.runtime.sendMessage(request);
+      const response: FormatResponse = await runtime.sendMessage(request);
       await setOption("prettierOptions", response.formatted);
       if (response.error) {
         alert(response.error);


### PR DESCRIPTION
This is frustrating...

Chrome requires a v3 manifest.  
That requires a service worker.  
Service workers cannot `import()`.   
But I need that for Firefox - FF cannot upload addons with files over 4M, so I need bundle splitting there, which I get using `import()`.